### PR TITLE
Mount the provider so CUE4 can find things.

### DIFF
--- a/LocalFetch.API/Utilities/FetchContext.cs
+++ b/LocalFetch.API/Utilities/FetchContext.cs
@@ -113,5 +113,6 @@ public class FetchContext
 
         if (MappingFilePath != null) Provider.MappingsContainer = new FileUsmapTypeMappingsProvider(MappingFilePath);
         Provider.LoadVirtualPaths();
+        Provider.Mount();
     }
 }


### PR DESCRIPTION
JsonAsAsset doesn't work right now because of this missing line, if you don't mount the provider, it never finds any assets, and therefore can't extract anything.